### PR TITLE
projects.yaml: specify extra dependencies of plugins, per-key

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -67,6 +67,9 @@ projects:
   category: api-docs
 - name: mkdocstrings
   mkdocs_plugin: mkdocstrings
+  extra_dependencies:
+    mkdocstrings.handlers.crystal: mkdocstrings-crystal
+    mkdocstrings.handlers.python: mkdocstrings-python
   github_id: mkdocstrings/mkdocstrings
   pypi_id: mkdocstrings
   labels: [plugin]


### PR DESCRIPTION
The idea is for `mkdocs get-deps` to look at particular keys of plugins' configs and install additional dependencies that they are known to require.

This is also a potential candidate, but is not yet handled:
https://squidfunk.github.io/mkdocs-material/setup/dependencies/image-processing/
